### PR TITLE
Factoring out absolute positioning

### DIFF
--- a/src/styles/app.less
+++ b/src/styles/app.less
@@ -30,24 +30,21 @@ body {
     border-radius: 1000px;
     border: none;
     background-color: white;
+    position: absolute;
 
     &#btn-up {
-      position: absolute;
       left: @btn-size;
       top: 0px;
     }
     &#btn-left {
-      position: absolute;
       left: 0px;
       top: @btn-size * 0.6;
     }
     &#btn-right {
-      position: absolute;
       right: 0px;
       top: @btn-size * 0.6;
     }
     &#btn-down {
-      position: absolute;
       left: @btn-size;
       bottom: 0px;
     }


### PR DESCRIPTION
Not entirely sure why this is specified for each button. Looks like it can be factored out.